### PR TITLE
Ensure function types referenced by struct types are declared (fix #101)

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3511,6 +3511,10 @@ void CWriter::forwardDeclareStructs(raw_ostream &Out, Type *Ty,
 
   if (StructType *ST = dyn_cast<StructType>(Ty)) {
     Out << getStructName(ST) << ";\n";
+  } else if (auto *FT = dyn_cast<FunctionType>(Ty)) {
+    // Ensure function types which are only directly used by struct types will
+    // get declared.
+    (void)getFunctionName(FT);
   }
 }
 

--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -3445,12 +3445,12 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
     FunctionType *FT = F.first;
     std::vector<FunctionType *> FDeps;
     for (const auto P : F.first->params()) {
-      if (P->isPointerTy()) {
-        PointerType *PP = dyn_cast<PointerType>(P);
-        if (PP->getElementType()->isFunctionTy()) {
-          FDeps.push_back(dyn_cast<FunctionType>(PP->getElementType()));
-        }
-      }
+      // Handle arbitrarily deep pointer indirection
+      Type *PP = P;
+      while (PP->isPointerTy())
+        PP = PP->getPointerElementType();
+      if (auto *PPF = dyn_cast<FunctionType>(PP))
+        FDeps.push_back(PPF);
     }
     std::string DeclString;
     raw_string_ostream TmpOut(DeclString);

--- a/test/ll_tests/test_fun_ptr_dependencies.ll
+++ b/test/ll_tests/test_fun_ptr_dependencies.ll
@@ -1,0 +1,10 @@
+; This tests that CBE will emit function type definitions before other function
+; type definitions that use them, even in the presence of more than one level of
+; pointer indirection.
+
+%struct.funptr_struct = type { void (void ()**)*, void ()* }
+
+define i32 @main() {
+  %1 = alloca %struct.funptr_struct, align 8
+  ret i32 6
+}

--- a/test/ll_tests/test_fun_ptr_only_refd_by_struct.ll
+++ b/test/ll_tests/test_fun_ptr_only_refd_by_struct.ll
@@ -1,0 +1,9 @@
+; This tests whether the CBE will emit a definition for a function type whose
+; only direct reference is a struct type. (Issue #101)
+
+%struct.funptr_struct = type { void ()* }
+
+define i32 @main() {
+  %1 = alloca %struct.funptr_struct, align 8
+  ret i32 6
+}


### PR DESCRIPTION
This fixes my original Rust code from #101, my simple C reproducer, and I've even verified that it fixes the LLVM IR from #66.