### PR TITLE
Use "shorter representation" codepath for 64-bit integers

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -1290,8 +1290,7 @@ void CWriter::printConstant(Constant *CPV, enum OperandContext Context) {
     unsigned ActiveBits = CI->getValue().getMinSignedBits();
     if (Ty == Type::getInt1Ty(CPV->getContext())) {
       Out << (CI->getZExtValue() ? '1' : '0');
-    } else if (Context != ContextNormal && ActiveBits < 64 &&
-               Ty->getPrimitiveSizeInBits() < 64 &&
+    } else if (Context != ContextNormal && Ty->getPrimitiveSizeInBits() <= 64 &&
                ActiveBits < Ty->getPrimitiveSizeInBits()) {
       if (ActiveBits >= 32)
         Out << "INT64_C(";


### PR DESCRIPTION
Fixes a lot of cases of `(uint64_t)UINT64_C(0)` that should just be `(uint64_t)0`.

Some examples from a small program of mine:

```diff
<   _3 = llvm_lshr_u64(_1, UINT64_C(1));
---
>   _3 = llvm_lshr_u64(_1, 1);
90c90
<     _4__PHI_TEMPORARY = UINT64_C(0);   /* for PHI node */
---
>     _4__PHI_TEMPORARY = 0;   /* for PHI node */
99c99
<   _5 = llvm_add_u64(_4, UINT64_C(1));
---
>   _5 = llvm_add_u64(_4, 1);
157c157
<   uint32_t _23 = puts(((&str.array[((int64_t)UINT64_C(0))])));
---
>   uint32_t _23 = puts(((&str.array[((int64_t)0)])));
162c162
<   uint8_t* _25 = *((&_19[((int64_t)UINT64_C(1))]));
---
>   uint8_t* _25 = *((&_19[((int64_t)1)]));
165,166c165,166
<   uint32_t _28 = printf(((&_OC_str_OC_1.array[((int64_t)UINT64_C(0))])), _25, (((uint32_t)(bool)_27)));
<   uint8_t* _29 = *((&_19[((int64_t)UINT64_C(2))]));
---
>   uint32_t _28 = printf(((&_OC_str_OC_1.array[((int64_t)0)])), _25, (((uint32_t)(bool)_27)));
>   uint8_t* _29 = *((&_19[((int64_t)2)]));
169c169
<   uint32_t _32 = printf(((&_OC_str_OC_2.array[((int64_t)UINT64_C(0))])), _30, _31);
---
>   uint32_t _32 = printf(((&_OC_str_OC_2.array[((int64_t)0)])), _30, _31);
```

The condition I am changing was introduced by https://github.com/JuliaComputingOSS/llvm-cbe/commit/7da56e67e8505116aed007a45f467d84c96127e2.