### PR TITLE
Update README claims of LLVM support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ This LLVM C backend has been resurrected by Julia Computing with various improve
 Installation instructions
 =========================
 
-This version of the LLVM C backend works with LLVM 10.0.
-
-Earlier versions are supported too (LLVM 7 and earlier should work).
+This version of the LLVM C backend works with LLVM 10.0, and has preliminary support for LLVM 11.0.
 
 Step 1: Installing LLVM
 =======================


### PR DESCRIPTION
Re: https://github.com/JuliaComputingOSS/llvm-cbe/issues/119 and https://github.com/JuliaComputingOSS/llvm-cbe/pull/91.

Relevant to https://github.com/JuliaComputingOSS/llvm-cbe/issues/60, but does not implement it. As a practical matter: I am using LLVM 10 right now, there probably isn't full LLVM 11 support, and the latest version of LLVM is 12 which doesn't work yet (https://github.com/JuliaComputingOSS/llvm-cbe/issues/116).

Btw, I'm also wondering if we should remove the ifdef's for 9 and below.