### PR TITLE
Handle simple manipulation of pointers to zero-element arrays (fix #128)

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -93,6 +93,12 @@ enum UnaryOps {
   }
 #endif
 
+static bool isConstantNull(Value *V) {
+  if (Constant *C = dyn_cast<Constant>(V))
+    return C->isNullValue();
+  return false;
+}
+
 static bool isEmptyType(Type *Ty) {
   if (StructType *STy = dyn_cast<StructType>(Ty))
     return STy->getNumElements() == 0 ||
@@ -108,6 +114,14 @@ static bool isEmptyType(Type *Ty) {
 }
 
 bool CWriter::isEmptyType(Type *Ty) const { return llvm_cbe::isEmptyType(Ty); }
+
+/// Peel off outer array types which have zero elements.
+/// This is useful for pointers types. It isn't reasonable for values.
+Type *CWriter::skipEmptyArrayTypes(Type *Ty) const {
+  while (Ty->isArrayTy() && Ty->getArrayNumElements() == 0)
+    Ty = Ty->getArrayElementType();
+  return Ty;
+}
 
 /// isAddressExposed - Return true if the specified value's name needs to
 /// have its address taken in order to get a C value of the correct type.
@@ -530,6 +544,7 @@ CWriter::printTypeName(raw_ostream &Out, Type *Ty, bool isSigned,
 
   case Type::PointerTyID: {
     Type *ElTy = Ty->getPointerElementType();
+    ElTy = skipEmptyArrayTypes(ElTy);
     return printTypeName(Out, ElTy, false) << '*';
   }
 
@@ -5289,7 +5304,7 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
   Value *FirstOp = I.getOperand();
   IntoT = I.getIndexedType();
   ++I;
-  if (!isa<Constant>(FirstOp) || !cast<Constant>(FirstOp)->isNullValue()) {
+  if (!isConstantNull(FirstOp)) {
     writeOperand(Ptr);
     Out << '[';
     writeOperandWithCast(FirstOp, Instruction::GetElementPtr);
@@ -5315,26 +5330,42 @@ void CWriter::printGEPExpression(Value *Ptr, gep_type_iterator I,
   }
 
   for (; I != E; ++I) {
+    Value *Opnd = I.getOperand();
+
     cwriter_assert(
-        I.getOperand()
+        Opnd
             ->getType()
             ->isIntegerTy()); // TODO: indexing a Vector with a Vector is valid,
                               // but we don't support it here
+
     if (I.isStruct()) {
-      Out << ".field" << cast<ConstantInt>(I.getOperand())->getZExtValue();
+      Out << ".field" << cast<ConstantInt>(Opnd)->getZExtValue();
     } else if (IntoT->isArrayTy()) {
-      Out << ".array[";
-      writeOperandWithCast(I.getOperand(), Instruction::GetElementPtr);
-      Out << ']';
+      // Zero-element array types are either skipped or, for pointers, peeled
+      // off by skipEmptyArrayTypes. In this latter case, we can translate
+      // zero-element array indexing as pointer arithmetic.
+      if (IntoT->getArrayNumElements() == 0) {
+        if (!isConstantNull(Opnd)) {
+          // TODO: The operator precedence here is only correct if there are no
+          //       subsequent indexable types other than zero-element arrays.
+          cwriter_assert(skipEmptyArrayTypes(IntoT)->isSingleValueType());
+          Out << " + (";
+          writeOperandWithCast(Opnd, Instruction::GetElementPtr);
+          Out << ')';
+        }
+      } else {
+        Out << ".array[";
+        writeOperandWithCast(Opnd, Instruction::GetElementPtr);
+        Out << ']';
+      }
     } else if (!IntoT->isVectorTy()) {
       Out << '[';
-      writeOperandWithCast(I.getOperand(), Instruction::GetElementPtr);
+      writeOperandWithCast(Opnd, Instruction::GetElementPtr);
       Out << ']';
     } else {
       // If the last index is into a vector, then print it out as "+j)".  This
       // works with the 'LastIndexIsVector' code above.
-      if (isa<Constant>(I.getOperand()) &&
-          cast<Constant>(I.getOperand())->isNullValue()) {
+      if (!isConstantNull(Opnd)) {
         Out << "))"; // avoid "+0".
       } else {
         Out << ")+(";

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -285,6 +285,7 @@ private:
   bool printConstantString(Constant *C, enum OperandContext Context);
 
   bool isEmptyType(Type *Ty) const;
+  Type *skipEmptyArrayTypes(Type *Ty) const;
   bool isAddressExposed(Value *V) const;
   bool isInlinableInst(Instruction &I) const;
   AllocaInst *isDirectAlloca(Value *V) const;

--- a/test/ll_tests/test_empty_array_geps.ll
+++ b/test/ll_tests/test_empty_array_geps.ll
@@ -1,0 +1,41 @@
+; This tests GEPs and Phi nodes for pointers to zero-sized arrays.
+; It is inspired by LLVM IR produced by rustc 1.45.0 for code like
+;
+; match some_expression {
+;   Case1 => "Test string",
+;   Case2 => "Different test string",
+; }.as_ptr()
+;
+; but with some simplifications.
+
+@correctStringConstant = constant [3 x i8] c"\01\02\03"
+@wrongStringConstant = constant [5 x i8] c"test\00"
+
+define i32 @main(i32 %argc, i8** %argv) {
+bb0:
+  %alwaysTrue = icmp eq i32 %argc, 1
+  br i1 %alwaysTrue, label %iftrue, label %iffalse
+
+iftrue:
+  br label %end
+
+iffalse:
+  br label %end
+
+end:
+  %stringConstant = phi [0 x i8]* [ bitcast ([3 x i8]* @correctStringConstant to [0 x i8]*), %iftrue ], [ bitcast ([5 x i8]* @wrongStringConstant to [0 x i8]*), %iffalse ]
+
+  %char1ptr = getelementptr [0 x i8], [0 x i8]* %stringConstant, i64 0, i64 0
+  %char2ptr = getelementptr [0 x i8], [0 x i8]* %stringConstant, i64 0, i64 1
+  %char3ptr = getelementptr [0 x i8], [0 x i8]* %stringConstant, i64 0, i64 2
+
+  %char1 = load i8, i8* %char1ptr
+  %char2 = load i8, i8* %char2ptr
+  %char3 = load i8, i8* %char3ptr
+
+  %sum12 = add i8 %char1, %char2
+  %sum = add i8 %sum12, %char3
+  %res = zext i8 %sum to i32
+
+  ret i32 %res
+}


### PR DESCRIPTION
Handle simple manipulation of pointers to zero-element arrays (fix #128)
    
So far, we have translated empty types (such as zero-element arrays) to C's void type. This works fine if a pointer to such a type is just an abstract handle, but since you can't do pointer arithmetic on a void pointer, it does not work for LLVM GEPs.
    
This commit applies a new strategy for pointers to zero-element arrays. Instead of treating the array as void, we peel off the array and use its element type as the pointer target. In other words, we treat `[Ty x 0]*` as if it were `Ty*`. This makes simple pointer arithmetic possible.
    
The new test (`test_empty_array_geps.ll`) shows the motivating use-case.

----

This doesn't break any existing tests, and seems to fix the original case I was interested in (https://github.com/JuliaComputingOSS/llvm-cbe/issues/128). I haven't tested it very deeply, though. If you have any thoughts on particular problem areas that may have been missed, I'd love to know.