### PR TITLE
Fix missing brace that breaks build for LLVM < 10.x

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,12 @@ if (NOT DEFINED LLVM_VERSION_MAJOR)
   set (CMAKE_CXX_STANDARD 14)
 endif()
 
+if(LLVM_VERSION_MAJOR LESS 8)
+  message(FATAL_ERROR "This project isn't buldable with LLVM < 8.0.0.")
+elseif(LLVM_VERSION_MAJOR LESS 10)
+  message(WARNING "Building with LLVM < 10.0.0 is at your own risk.")
+endif()
+
 add_subdirectory(lib)
 add_subdirectory(tools)
 

--- a/tools/llvm-cbe/llvm-cbe.cpp
+++ b/tools/llvm-cbe/llvm-cbe.cpp
@@ -398,7 +398,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   if (RelaxAll) {
     if (FileType != CodeGenFileType::CGFT_ObjectFile)
 #else
-  {
+  if (RelaxAll) {
     if (FileType != TargetMachine::CGFT_ObjectFile)
 #endif
       errs() << argv[0]

--- a/tools/llvm-cbe/llvm-cbe.cpp
+++ b/tools/llvm-cbe/llvm-cbe.cpp
@@ -398,6 +398,7 @@ static int compileModule(char **argv, LLVMContext &Context) {
   if (RelaxAll) {
     if (FileType != CodeGenFileType::CGFT_ObjectFile)
 #else
+  {
     if (FileType != TargetMachine::CGFT_ObjectFile)
 #endif
       errs() << argv[0]


### PR DESCRIPTION
Despite of the fact LLVM 9.x is unsupported anymore by `llvm-cbe`, it still probably works in most cases, if this brace is fixed.

I guess if there's a decision to forbid builds for any LLVM < 10.x, an `#error` should be there instead of such mistake. Still `llvm-cbe` seems to be working for me with LLVM 9.0.1, so I see no reason to put `#error` there instead of this fix.

Should fix issues #130 and #119.