### PR TITLE
Ensure function and array types referenced by functions are declared

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -817,6 +817,9 @@ CWriter::printFunctionProto(raw_ostream &Out, FunctionType *FTy,
 
   for (; I != E; ++I) {
     Type *ArgTy = *I;
+    if (ArgTy->isMetadataTy())
+      continue;
+
     if (PAL.hasAttribute(Idx, Attribute::ByVal)) {
       cwriter_assert(!shouldFixMain);
       cwriter_assert(ArgTy->isPointerTy());
@@ -3469,14 +3472,16 @@ void CWriter::printModuleTypes(raw_ostream &Out) {
   // printed in the correct order.
   Out << "\n/* Types Declarations */\n";
 
-  // forward-declare all structs here first
-
+  // Collect types referenced by structs and global functions, and
+  // forward-declare the structs.
   {
     std::set<Type *> TypesPrinted;
     for (auto it = TypedefDeclTypes.begin(), end = TypedefDeclTypes.end();
          it != end; ++it) {
       forwardDeclareStructs(Out, *it, TypesPrinted);
     }
+    for (const Function &F : *TheModule)
+      forwardDeclareStructs(Out, F.getFunctionType(), TypesPrinted);
   }
 
   Out << "\n/* Function definitions */\n";
@@ -3560,6 +3565,10 @@ void CWriter::forwardDeclareStructs(raw_ostream &Out, Type *Ty,
 
   if (StructType *ST = dyn_cast<StructType>(Ty)) {
     Out << getStructName(ST) << ";\n";
+  // Since function declarations come before the definitions of array-wrapper
+  // structs, it is sometimes necessary to forward-declare those.
+  } else if (auto *AT = dyn_cast<ArrayType>(Ty)) {
+    Out << getArrayName(AT) << ";\n";
   } else if (auto *FT = dyn_cast<FunctionType>(Ty)) {
     // Ensure function types which are only directly used by struct types will
     // get declared.

--- a/test/ll_tests/test_fun_ptr_only_refd_by_function.ll
+++ b/test/ll_tests/test_fun_ptr_only_refd_by_function.ll
@@ -1,0 +1,10 @@
+; This tests whether the CBE will emit a definition for a function type whose
+; only direct reference is a function parameter list.
+
+%funptr = type void ()*
+
+declare i32 @someFun(%funptr)
+
+define i32 @main() {
+  ret i32 6
+}


### PR DESCRIPTION
A check is also added to skip metadata types in function parameter lists, which are seen in Clang output. This avoids an assertion.

----

This pull request fixes one of the issues described in https://github.com/JuliaComputingOSS/llvm-cbe/issues/132. The struct types change is the main part of this, but adding that revealed additional issues (metadata, array types) so I had to fix them too.

I'll freely admit this patch is suboptimal. It will create unused function typedefs for all the global functions, and I would guess it forward-declares array types unnecessarily sometimes. It does also fix real problems, though. I think in the longer term, it might be a good idea to completely rewrite the code for handling definitions and declarations…