### PR TITLE
cast to FixedVectorType instead of VectorType for llvm 10 above

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -288,7 +288,11 @@ raw_ostream &CWriter::printTypeString(raw_ostream &Out, Type *Ty,
 #endif
   {
     TypedefDeclTypes.insert(Ty);
+#if LLVM_VERSION_MAJOR > 10
+    FixedVectorType *VTy = cast<FixedVectorType>(Ty);
+#else
     VectorType *VTy = cast<VectorType>(Ty);
+#endif
     cwriter_assert(VTy->getNumElements() != 0);
     printTypeString(Out, VTy->getElementType(), isSigned);
     return Out << "x" << NumberOfElements(VTy);
@@ -1480,7 +1484,11 @@ void CWriter::printConstant(Constant *CPV, enum OperandContext Context) {
   case Type::VectorTyID:
 #endif
   {
+#if LLVM_VERSION_MAJOR > 10
+    FixedVectorType *VT = cast<FixedVectorType>(CPV->getType());
+#else
     VectorType *VT = cast<VectorType>(CPV->getType());
+#endif
     cwriter_assert(VT->getNumElements() != 0 && !isEmptyType(VT));
     if (Context != ContextStatic) {
       CtorDeclTypes.insert(VT);
@@ -2855,7 +2863,11 @@ void CWriter::generateHeader(Module &M) {
       printTypeName(Out, DstTy, DstSigned);
       Out << " out;\n";
       unsigned n, l = NumberOfElements(cast<VectorType>(DstTy));
+#if LLVM_VERSION_MAJOR > 10
+      cwriter_assert(cast<FixedVectorType>(SrcTy)->getNumElements() == l);
+#else
       cwriter_assert(cast<VectorType>(SrcTy)->getNumElements() == l);
+#endif
       for (n = 0; n < l; n++) {
         Out << "  out.vector[" << n << "] = in.vector[" << n << "];\n";
       }


### PR DESCRIPTION
Build failed with llvm13.0.0 with error:
```
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp: In member function ‘llvm::raw_ostream& llvm_cbe::CWriter::printTypeString(llvm::raw_ostream&, llvm::Type*, bool)’:       /mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:292:25: error: ‘class llvm::VectorType’ has no member named ‘getNumElements’; did you mean ‘getArrayNumElements’?
  292 |     cwriter_assert(VTy->getNumElements() != 0);
      |                         ^~~~~~~~~~~~~~
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:106:9: note: in definition of macro ‘cwriter_assert’
  106 |   if (!(expr)) {                                                               \
      |         ^~~~
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp: In member function ‘void llvm_cbe::CWriter::printConstant(llvm::Constant*, llvm_cbe::CWriter::OperandContext)’:
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:1484:24: error: ‘class llvm::VectorType’ has no member named ‘getNumElements’; did you mean ‘getArrayNumElements’?         1484 |     cwriter_assert(VT->getNumElements() != 0 && !isEmptyType(VT));
      |                        ^~~~~~~~~~~~~~
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:106:9: note: in definition of macro ‘cwriter_assert’
  106 |   if (!(expr)) {                                                               \
      |         ^~~~
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp: In member function ‘void llvm_cbe::CWriter::generateHeader(llvm::Module&)’:
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:2858:47: error: ‘class llvm::VectorType’ has no member named ‘getNumElements’; did you mean ‘getArrayNumElements’?         2858 |       cwriter_assert(cast<VectorType>(SrcTy)->getNumElements() == l);
      |                                               ^~~~~~~~~~~~~~
/mnt/r/llvm-cbe/lib/Target/CBackend/CBackend.cpp:106:9: note: in definition of macro ‘cwriter_assert’
  106 |   if (!(expr)) {                                                               \
      |         ^~~~
make[3]: *** [lib/Target/CBackend/CMakeFiles/LLVMCBackendCodeGen.dir/build.make:76: lib/Target/CBackend/CMakeFiles/LLVMCBackendCodeGen.dir/CBackend.cpp.o] Error 1
make[2]: *** [CMakeFiles/Makefile2:263: lib/Target/CBackend/CMakeFiles/LLVMCBackendCodeGen.dir/all] Error 2
make[1]: *** [CMakeFiles/Makefile2:427: tools/llvm-cbe/CMakeFiles/llvm-cbe.dir/rule] Error 2
make: *** [Makefile:286: llvm-cbe] Error 2
```
Fix:
cast to `FixedVectorType` instead of `VectorType`  for llvm 10 above