### PR TITLE
Update/polish shell code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,18 +15,18 @@ Either install the LLVM packages on your system:
 --------------------------------------------
 
 On macOS, use [pkgsrc](http://pkgsrc.joyent.com/install-on-osx/) and run the following commands:
-```
-    pkgin in llvm clang
+```sh
+    ~$ pkgin in llvm clang
 ```
 
 On CentOS, install the llvm-devel package:
-```
-    dnf install llvm-devel clang
+```sh
+    ~# dnf install llvm-devel clang
 ```
 
 On Debian and derivatives, install the llvm-dev package via:
-```
-    apt install llvm-dev clang
+```sh
+    ~# apt install llvm-dev clang
 ```
 
 Or compile LLVM yourself:
@@ -36,15 +36,15 @@ Note: to convert C to LLVM IR to run the tests, you will also need a C compiler 
 The first step is to compile LLVM on your machine
 (this assumes an in-tree build, but out-of-tree will also work):
 
-
-     git clone https://github.com/llvm/llvm-project.git
-     cd llvm-project
-     git checkout release/8.x
-     mkdir llvm/build
-     cd llvm/build
-     cmake ..
-     make
-
+```sh
+     ~$ git clone https://github.com/llvm/llvm-project.git
+     ~$ cd llvm-project
+     llvm-project$ git checkout release/8.x
+     llvm-project$ mkdir llvm/build
+     llvm-project$ cd llvm/build
+     build$ cmake ..
+     build$ make
+```
 To run tests, you need to build `lli`.
 
 
@@ -54,32 +54,32 @@ Step 2: Compiling LLVM-CBE
 Now you can download and compile llvm-cbe.
 
 If you built LLVM yourself, put it in the same folder you built LLVM in:
-
-    cd $HOME/llvm-project/llvm/projects
-    git clone https://github.com/JuliaComputing/llvm-cbe
-    cd ../build
-    cmake -S ..
-    make llvm-cbe
-
+```sh
+    ~$ cd llvm-project/llvm/projects
+    projects$ git clone https://github.com/JuliaComputing/llvm-cbe
+    projects$ cd ../build
+    build$ cmake -S ..
+    build$ make llvm-cbe
+```
 If you used your distribution's package, put it wherever you feel like:
-
-    git clone https://github.com/JuliaComputing/llvm-cbe
-    cd llvm-cbe && mkdir build && cd build
-    cmake -S ..
-    make llvm-cbe
-
+```sh
+    ~$ git clone https://github.com/JuliaComputing/llvm-cbe
+    ~$ cd llvm-cbe && mkdir build && cd build
+    build$ cmake -S ..
+    build$ make llvm-cbe
+```
 Step 3: Usage Examples
 ======================
 
 If llvm-cbe compiles, you should be able to run it with the following commands.
-```
-$ cd $HOME/llvm-project/llvm/projects/llvm-cbe/test/selectionsort
-$ ls
-main.c
-$ clang -S -emit-llvm -g main.c
-$ ls
-main.c main.ll
-$ $(HOME)/llvm/build/bin/llvm-cbe main.ll
+```sh
+    llvm-cbe$ cd test/selectionsort
+    selectionsort$ ls
+    main.c
+    selectionsort$ clang -S -emit-llvm -g main.c
+    selectionsort$ ls
+    main.c main.ll
+    selectionsort$ ../../build/tools/llvm-cbe/llvm-cbe main.ll
 ```
 
 You can find options to configure the C backend's output with `llvm-cbe --help`.
@@ -88,11 +88,11 @@ Look for options beginning with `--cbe-`.
 Compile Generated C Code and Run
 ================================
 
-```
-$ gcc -o main.cbe main.cbe.c
-$ ls
-main.c  main.cbe  main.cbe.c  main.ll
-$ ./main.cbe
+```sh
+    selectionsort$ gcc -o main.cbe main.cbe.c
+    selectionsort$ ls
+    main.c  main.cbe  main.cbe.c  main.ll
+    selectionsort$ ./main.cbe
 ```
 
 Running tests
@@ -101,8 +101,8 @@ Running tests
 Unit tests:
 
 ```sh
-    $ cd $HOME/llvm-project/llvm/build
-    $ make CBEUnitTests && projects/llvm-cbe/unittests/CWriterTest
+    llvm-project$ cd llvm/build
+    build$ make CBEUnitTests && projects/llvm-cbe/unittests/CWriterTest
 ```
 
 Note that you need to have passed `-DLLVM_INCLUDE_TESTS=1` to cmake if you used
@@ -114,8 +114,7 @@ Other tests:
 First, compile llvm-cbe, and install pytest (e.g. `pip install pytest`). Then:
 
 ```sh
-    $ cd $HOME/llvm-project/llvm/projects/llvm-cbe
-    $ pytest
+    llvm-cbe$ pytest
 ```
 
 You might have to adjust the llvm-cbe and lli paths in that configuration.


### PR DESCRIPTION
Upon installing llvm-cbe for my first time, I noticed a few of the shell steps in the README were incorrect, and in general inconsistent in style across the whole file.

I’m open to suggestions regarding how to display the directory from which to run each command.