### PR TITLE
Add support for constant variables

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -2478,6 +2478,9 @@ void CWriter::generateHeader(Module &M) {
       if (!I->isDeclaration())
         continue;
 
+      if (I->isConstant())
+        Out << "const ";
+
       if (I->hasDLLImportStorageClass())
         Out << "__declspec(dllimport) ";
       else if (I->hasDLLExportStorageClass())
@@ -3371,6 +3374,9 @@ void CWriter::declareOneGlobalVariable(GlobalVariable *I) {
 
   if (I->hasLocalLinkage())
     Out << "static ";
+
+  if (I->isConstant())
+    Out << "const ";
 
   // Thread Local Storage
   if (I->isThreadLocal())


### PR DESCRIPTION
Some targets do benefit from explicitly declaring constant variables as const. llvm-ir already identifies constant symbols, so the change is relatively straightforward.