### PR TITLE
Fix byval args (e.g. large structs)

### DIFF
--- a/lib/Target/CBackend/CBackend.cpp
+++ b/lib/Target/CBackend/CBackend.cpp
@@ -142,7 +142,7 @@ Type *CWriter::skipEmptyArrayTypes(Type *Ty) const {
 /// This happens for global variables, byval parameters, and direct allocas.
 bool CWriter::isAddressExposed(Value *V) const {
   if (Argument *A = dyn_cast<Argument>(V))
-    return ByValParams.count(A) > 0;
+    return A->hasByValAttr();
   else
     return isa<GlobalVariable>(V) || isDirectAlloca(V);
 }
@@ -2381,7 +2381,6 @@ bool CWriter::doFinalization(Module &M) {
   MOFI = nullptr;
 
   FPConstantMap.clear();
-  ByValParams.clear();
   AnonValueNumbers.clear();
   UnnamedStructIDs.clear();
   UnnamedFunctionIDs.clear();

--- a/lib/Target/CBackend/CBackend.h
+++ b/lib/Target/CBackend/CBackend.h
@@ -68,7 +68,6 @@ class CWriter : public FunctionPass, public InstVisitor<CWriter> {
   const Instruction *CurInstr = nullptr;
 
   IDMap<const ConstantFP *> FPConstantMap;
-  std::set<const Argument *> ByValParams;
 
   IDMap<const Value *> AnonValueNumbers;
 

--- a/test/ll_tests/test_byval_struct_param.ll
+++ b/test/ll_tests/test_byval_struct_param.ll
@@ -1,0 +1,30 @@
+; Test byval parameter attribute works.
+
+%struct.intbox = type { i32 }
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define void @add(%struct.intbox* noalias sret %0, %struct.intbox* byval(%struct.intbox) align 4 %1, %struct.intbox* byval(%struct.intbox) align 4 %2) #0 {
+  %4 = getelementptr inbounds %struct.intbox, %struct.intbox* %1, i32 0, i32 0
+  %5 = load i32, i32* %4, align 4
+  %6 = getelementptr inbounds %struct.intbox, %struct.intbox* %2, i32 0, i32 0
+  %7 = load i32, i32* %6, align 4
+  %8 = add nsw i32 %5, %7
+  %9 = getelementptr inbounds %struct.intbox, %struct.intbox* %0, i32 0, i32 0
+  store i32 %8, i32* %9, align 4
+  ret void
+}
+
+; Function Attrs: noinline nounwind optnone ssp uwtable
+define i32 @main(i32 %0, i8** %1) #0 {
+  %3 = alloca %struct.intbox, align 4
+  %4 = getelementptr inbounds %struct.intbox, %struct.intbox* %3, i32 0, i32 0
+  store i32 2, i32* %4, align 4
+  %5 = alloca %struct.intbox, align 4
+  %6 = getelementptr inbounds %struct.intbox, %struct.intbox* %5, i32 0, i32 0
+  store i32 4, i32* %6, align 4
+  %7 = alloca %struct.intbox, align 4
+  call void @add(%struct.intbox* sret %7, %struct.intbox* byval(%struct.intbox) align 4 %3, %struct.intbox* byval(%struct.intbox) align 4 %5)
+  %8 = getelementptr inbounds %struct.intbox, %struct.intbox* %7, i32 0, i32 0
+  %9 = load i32, i32* %8, align 4
+  ret i32 %9
+}


### PR DESCRIPTION
This must have regressed at some point, because the existence of `ByValParams` suggests there used to be handling of it.

The problem is that if you have a `byval` struct argument (produced for e.g. `void foo(some_large_struct bar)`) then it's a pointer type in LLVM, but in C it's a by-value struct argument, so we need to add `&` in front of it.